### PR TITLE
SCI-506: fix DFT unit functional issue during JS test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/schema/models_directory/pb/qm/dft/dft_unit_functionals.json filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ lib/
 *.py[cod]
 
 dist/
-/schema/models_directory/pb/qm/dft/dft_unit_functionals.json

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This directory contains Python and Javascript interfaces implementing the functi
 The list of DFT unit functionals (`dft_unit_functionals.json`) is currently tracked via [git LFS](https://git-lfs.github.com).
 If one wishes to add a new unit functional to that list, please
 - edit the [prototype file](schema/models_directory/pb/qm/dft/dft_unit_functionals_proto.json) and
-- generate a new list of unit functional by invoking `generate_dft_unit_functionals()` from the [esse.functionals](src/py/esse/functionals.py) python module.
+- generate a new list of unit functional by running python tests, for example (via `generate_dft_unit_functionals()` from the [esse.functionals](src/py/esse/functionals.py) python module).
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Note: A list of DFT unit functionals (`dft_unit_functionals.json`) is generated 
 
 This directory contains Python and Javascript interfaces implementing the functionality to access and validate schemas and examples.
 
+### A word on functionals
+The list of DFT unit functionals (`dft_unit_functionals.json`) is currently tracked via [git LFS](https://git-lfs.github.com).
+If one wishes to add a new unit functional to that list, please
+- edit the [prototype file](schema/models_directory/pb/qm/dft/dft_unit_functionals_proto.json) and
+- generate a new list of unit functional by invoking `generate_dft_unit_functionals()` from the [esse.functionals](src/py/esse/functionals.py) python module.
+
 ## Tests
 
 Execute the following command from the root directory of this repository to run the tests. The script will run both Javascript and Python tests in which examples are validated against the corresponding schemas.

--- a/schema/models_directory/pb/qm/dft/dft_unit_functionals.json
+++ b/schema/models_directory/pb/qm/dft/dft_unit_functionals.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed8140445f721de8dfd72be1c89beb4cb76bedaf21a37dd3ccd552adc513941c
+size 36592


### PR DESCRIPTION
The file `/schema/models_directory/pb/qm/dft/dft_unit_functionals.json` is only created during the Python tests and thus causes the JS tests to fail if they are run first. The changes herein add this file as a text pointer.