### PR TITLE
SOF-6500: accelerate python units

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 coverage==5.5
 exabyte-json-include==2021.05.06
 jsonschema==2.6.0
-python-slugify==2.0.1
+python-slugify>=7.0.0
 PyYAML==5.4
 toml==0.10.2
 Unidecode==1.1.1


### PR DESCRIPTION
This PR updates the version of `python-slugify` according to the official recommendation: https://pypi.org/project/python-slugify/