### PR TITLE
feat:SOF-7065: average, bands, and dos schemas

### DIFF
--- a/schema/3pse/file/applications/espresso/7.2/average.x.json
+++ b/schema/3pse/file/applications/espresso/7.2/average.x.json
@@ -1,0 +1,64 @@
+{
+    "$id": "3pse/file/applications/espresso/7.2/average.x",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "averagex schema",
+    "additionalProperties": false,
+    "description": "https://gitlab.com/QEF/q-e/blob/develop/PP/src/average.f90",
+    "properties": {
+        "nfile": {
+            "type": "integer",
+            "description": "the number of files containing the desired quantities"
+        },
+        "file_params": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/file_params"
+            },
+            "minItems": 1
+        }
+
+    },
+    "required": [
+        "nfile",
+        "file_params"
+    ],
+    "definitions": {
+        "file_params": {
+            "type": "object",
+            "properties": {
+                "filename": {
+                    "type": "string",
+                    "description": "the name of the n-th file"
+                },
+                "weight": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "description": "the weight w_n of the quantity read from n-th file"
+                },
+                "npt": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "the number of points for the final interpolation of the planar and macroscopic averages"
+                },
+                "idir": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3,
+                    "description": "Planar average is done in the plane orthogonal to direction `idir`, as defined for the crystal cell"
+                },
+                "awin": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "description": "the size of the window for macroscopic average (a.u.)"
+                }
+            },
+            "required": [
+                "filename",
+                "weight",
+                "npt",
+                "idir",
+                "awin"
+            ]
+        }
+    }
+}

--- a/schema/3pse/file/applications/espresso/7.2/bands.x.json
+++ b/schema/3pse/file/applications/espresso/7.2/bands.x.json
@@ -1,0 +1,86 @@
+{
+    "$id": "3pse/file/applications/espresso/7.2/bands.x",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "bandsx schema",
+    "additionalProperties": false,
+    "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html",
+    "properties": {
+        "prefix": {
+            "type": "string",
+            "default": "pwscf",
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm13"
+        },
+        "outdir": {
+            "type": "string",
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm16"
+        },
+        "filband": {
+            "type": "string",
+            "default": "bands.out",
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm19"
+        },
+        "spin_component": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2,
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm22"
+        },
+        "lsigma": {
+            "type": "array",
+            "items": {
+                "type": "boolean",
+                "minItems": 3
+            },
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm24"
+        },
+        "lp": {
+            "type": "boolean",
+            "default": false,
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm26"
+        },
+        "filp": {
+            "type": "string",
+            "default": "p_avg.dat",
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm30"
+        },
+        "lsym": {
+            "type": "boolean",
+            "default": true,
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm34"
+        },
+        "no_overlap": {
+            "type": "boolean",
+            "default": true,
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm37"
+        },
+        "plot_2d": {
+            "type": "boolean",
+            "default": false,
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm41"
+        },
+        "firstk": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm46"
+        },
+        "lastk": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "https://www.quantum-espresso.org/Doc/INPUT_BANDS.html#idm47"
+        }
+    },
+    "required": [
+        "prefix",
+        "outdir",
+        "filband",
+        "spin_component",
+        "lsigma",
+        "lp",
+        "filp",
+        "lsym",
+        "no_overlap",
+        "plot_2d",
+        "firstk",
+        "lastk"
+    ]
+}

--- a/schema/3pse/file/applications/espresso/7.2/dos.x.json
+++ b/schema/3pse/file/applications/espresso/7.2/dos.x.json
@@ -1,0 +1,52 @@
+{
+    "$id": "3pse/file/applications/espresso/7.2/dos.x",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "dosx schema",
+    "additionalProperties": false,
+    "description": "https://www.quantum-espresso.org/Doc/INPUT_DOS.html",
+    "properties": {
+        "dos": {
+            "type": "object",
+            "properties": {
+                "prefix": {
+                    "type": "string",
+                    "default": "pwscf"
+                },
+                "outdir": {
+                    "type": "string"
+                },
+                "bz_sum": {
+                    "type": "string",
+                    "enum": ["smearing", "tetrahedra", "tetrahedra_lin", "tetrahedra_opt"],
+                    "default": "smearing"
+                },
+                "ngauss": {
+                    "type": "integer",
+                    "enum": [0, 1, -1, -99]
+                },
+                "degauss": {
+                    "type": "number"
+                },
+                "Emin": {
+                    "type": "number"
+                },
+                "Emax": {
+                    "type": "number"
+                },
+                "DeltaE": {
+                    "type": "number"
+                },
+                "fildos": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DeltaE"
+            ]
+        }
+
+    },
+    "required": [
+        "dos"
+    ]
+}

--- a/schema/3pse/file/applications/espresso/7.2/pw.x.json
+++ b/schema/3pse/file/applications/espresso/7.2/pw.x.json
@@ -1,7 +1,7 @@
 {
     "$id": "3pse/file/applications/espresso/7.2/pw.x",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "pwx main schema",
+    "title": "pwx schema",
     "additionalProperties": false,
     "properties": {
         "control": {


### PR DESCRIPTION
Adds the manually created average bands and dos schemas. May recieve minor updates once automatic generation is possible