### PR TITLE
SOF-7293: missing esse types fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "./lib/js/esse/*": "./lib/js/esse/*.js",
         "./lib/js/json_include/*": "./lib/js/json_include/*.js",
         "./lib/js/scripts/*": "./lib/js/scripts/*.js",
-        "./lib/js/types.ts": "./lib/js/scripts/types.ts",
+        "./lib/js/types.ts": "./lib/js/types.ts",
         "./lib/js/schemas.json": "./lib/js/schemas.ts"
     }
 }


### PR DESCRIPTION
`type.ts` resides in `lib/js` after build. I guess old path is a typo.
![image](https://github.com/Exabyte-io/esse/assets/3978089/5b2348eb-97c4-4b58-bb76-1c6823ad0fa0)
